### PR TITLE
Setup Mailgun

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Qaror::Application.configure do
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],
     :authentication => :plain,
-    :domain         => APP_CONFIG['app_domain'],
+    :domain         => ENV['MAILGUN_SMTP_DOMAIN'],
     :enable_starttls_auto => true
   }
 


### PR DESCRIPTION
# Reason for change

We're using different domain names for the current app and in the Mailgun config. We need to use a separate ENV variable to fix that.

# Changes

- Add SMTP domain name ENV